### PR TITLE
chore: updates the default model to the GA version of gemini flash

### DIFF
--- a/.changeset/clear-onions-mix.md
+++ b/.changeset/clear-onions-mix.md
@@ -1,0 +1,5 @@
+---
+"@withmantle/tracewright": patch
+---
+
+chore: updates Gemini model version to GA 2.5 Flash

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The default is but this can be overridden with the GEMINI_MODEL environment vari
 
 ex.
 ```
-export GEMINI_MODEL=gemini-2.5-flash-preview-05-20
+export GEMINI_MODEL=gemini-2.5-pro
 ```
 
 ## Why build this tool?

--- a/src/llm_providers/gemini_provider.test.ts
+++ b/src/llm_providers/gemini_provider.test.ts
@@ -266,7 +266,7 @@ describe("GeminiProvider", () => {
         );
         expect(mockGenerateContent).toHaveBeenCalledTimes(1);
         const calledWith = mockGenerateContent.mock.calls[0][0] as GenerateContentParameters;
-        expect(calledWith.model).toBe("gemini-2.5-pro-preview-05-06");
+        expect(calledWith.model).toBe("gemini-2.5-flash");
     });
 
     it("should throw error if parseCodeResponse finds no matches in a malformed code block", async () => {

--- a/src/llm_providers/gemini_provider.ts
+++ b/src/llm_providers/gemini_provider.ts
@@ -105,7 +105,7 @@ export class GeminiProvider implements LLMProvider {
     parts.push({ text: scenarioText } as Content);
 
     return {
-      model: process.env.GEMINI_MODEL || "gemini-2.5-pro-preview-05-06",
+      model: process.env.GEMINI_MODEL || "gemini-2.5-flash",
       contents: parts,
       config: {
         systemInstruction,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2cf27009-aa85-4b8a-9af2-c42a4c3f82b5)


This updates the default model used from the 2.5 pro preview to the GA 2.5 flash.

Testing has found that 2.5 Flash performs just as well as Pro for our use cases, while being much cheaper and performant.

References:
https://blog.google/products/gemini/gemini-2-5-model-family-expands/
https://cloud.google.com/vertex-ai/generative-ai/pricing

