### PR TITLE
chore: add license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@withmantle/tracewright",
   "version": "0.1.2",
+  "license": "Apache-2.0",
   "main": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Summary:
- Add Apache-2.0 license metadata to the package manifest, matching the repository LICENSE.

Validation:
- node package metadata assertion
- npm pack --dry-run --json --ignore-scripts
- npm test -- --run
- git diff --check